### PR TITLE
feat: display notifications with high importance in modals

### DIFF
--- a/apps/app/lib/app/balance/user_params.ex
+++ b/apps/app/lib/app/balance/user_params.ex
@@ -40,7 +40,6 @@ defmodule App.Balance.UserParams do
   defp validate_means_code(changeset) do
     changeset
     |> validate_required(:means_code)
-    |> validate_inclusion(:means_code, Means.codes_with_user_params())
   end
 
   defp validate_params(changeset) do

--- a/apps/app/lib/app/books/members/book_member.ex
+++ b/apps/app/lib/app/books/members/book_member.ex
@@ -48,7 +48,6 @@ defmodule App.Books.Members.BookMember do
   defp validate_role(changeset) do
     changeset
     |> validate_required(:role)
-    |> validate_inclusion(:role, Role.all())
   end
 
   defp validate_book_id(changeset) do

--- a/apps/app/lib/app/notifications.ex
+++ b/apps/app/lib/app/notifications.ex
@@ -138,16 +138,19 @@ defmodule App.Notifications do
       ** (Ecto.NoResultsError)
 
   """
-  @spec read_notification(User.t(), Notification.t()) :: {:ok, Recipient.t()}
+  @spec read_notification(User.t(), Notification.t()) :: {:ok, Notification.t()}
   def read_notification(%User{} = user, %Notification{} = notification) do
     recipient = Repo.get_by!(Recipient, user_id: user.id, notification_id: notification.id)
 
     if recipient.read_at do
-      {:ok, recipient}
+      {:ok, notification}
     else
-      recipient
-      |> Recipient.changeset(%{read_at: NaiveDateTime.utc_now()})
-      |> Repo.update()
+      updated_recipient =
+        recipient
+        |> Recipient.changeset(%{read_at: NaiveDateTime.utc_now()})
+        |> Repo.update!()
+
+      {:ok, %{notification | read_at: updated_recipient.read_at}}
     end
   end
 

--- a/apps/app/lib/app/notifications.ex
+++ b/apps/app/lib/app/notifications.ex
@@ -32,7 +32,9 @@ defmodule App.Notifications do
   defp user_notifications_query(user_id) do
     from notification in Notification,
       join: recipient in assoc(notification, :recipients),
-      where: recipient.user_id == ^user_id
+      where: recipient.user_id == ^user_id,
+      select_merge: %{read_at: recipient.read_at},
+      order_by: [asc: notification.inserted_at]
   end
 
   @doc """

--- a/apps/app/lib/app/notifications.ex
+++ b/apps/app/lib/app/notifications.ex
@@ -131,10 +131,10 @@ defmodule App.Notifications do
 
   ## Examples
 
-      iex> mark_as_read(user, notification)
+      iex> read_notification(user, notification)
       %Notification{}
 
-      iex> mark_as_read(user, notification_not_for_user)
+      iex> read_notification(user, notification_not_for_user)
       ** (Ecto.NoResultsError)
 
   """

--- a/apps/app/lib/app/notifications/notification.ex
+++ b/apps/app/lib/app/notifications/notification.ex
@@ -35,6 +35,9 @@ defmodule App.Notifications.Notification do
     field :content, :string
     field :importance, Ecto.Enum, values: @notification_importances
 
+    # Filled with the value of `read_at` of the recipient, for the current user.
+    field :read_at, :naive_datetime, virtual: true
+
     has_many :recipients, Recipient
     many_to_many :users, User, join_through: Recipient
 

--- a/apps/app/lib/app/notifications/notification.ex
+++ b/apps/app/lib/app/notifications/notification.ex
@@ -55,7 +55,6 @@ defmodule App.Notifications.Notification do
   defp validate_importance(changeset) do
     changeset
     |> validate_required(:importance)
-    |> validate_inclusion(:importance, @notification_importances)
   end
 
   defp validate_content(changeset) do

--- a/apps/app/lib/app/transfers/money_transfer.ex
+++ b/apps/app/lib/app/transfers/money_transfer.ex
@@ -83,7 +83,6 @@ defmodule App.Transfers.MoneyTransfer do
   defp validate_type(changeset) do
     changeset
     |> validate_required(:type)
-    |> validate_inclusion(:type, @transfer_types)
   end
 
   defp validate_book_id(changeset) do

--- a/apps/app/test/app/notifications_test.exs
+++ b/apps/app/test/app/notifications_test.exs
@@ -71,7 +71,7 @@ defmodule App.NotificationsTest do
       user = user_fixture()
       notification = notification_fixture([user])
 
-      assert {:ok, %Recipient{}} = Notifications.read_notification(user, notification)
+      assert {:ok, %Notification{}} = Notifications.read_notification(user, notification)
       assert Notifications.read?(user, notification)
     end
 

--- a/apps/app_web/assets/css/components/modal.css
+++ b/apps/app_web/assets/css/components/modal.css
@@ -64,7 +64,8 @@
     }
 
     .modal--xl .modal__dialog {
-      @apply h-auto max-w-2xl;
+      @apply h-auto max-w-3xl
+             rounded-lg;
     }
   }
 }

--- a/apps/app_web/lib/app_web.ex
+++ b/apps/app_web/lib/app_web.ex
@@ -96,6 +96,9 @@ defmodule AppWeb do
       # Import basic rendering functionality (render, render_layout, etc)
       import Phoenix.View
 
+      # Alias LiveView javascript functions
+      alias Phoenix.LiveView.JS
+
       import AppWeb.ErrorHelpers
       import AppWeb.Gettext
       alias AppWeb.Router.Helpers, as: Routes

--- a/apps/app_web/lib/app_web/components/notification_menu.ex
+++ b/apps/app_web/lib/app_web/components/notification_menu.ex
@@ -15,13 +15,6 @@ defmodule AppWeb.NotificationMenu do
      |> assign(:displayed_notification, displayed_notification(notifications))}
   end
 
-  # Notifications with high importance are displayed in a in a prominent and intrusive way.
-  # We only display one notification at a time, and therefore we pick the first one which
-  # is not read yet.
-  defp displayed_notification(notifications) do
-    Enum.find(notifications, &(is_nil(&1.read_at) and &1.importance == :high))
-  end
-
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
@@ -49,7 +42,7 @@ defmodule AppWeb.NotificationMenu do
     %{user: user, notifications: notifications} = socket.assigns
 
     {:ok, read_notification} =
-      Notifications.read_notification(user, %Notification{id: notification_id})
+      Notifications.read_notification(user, Notifications.get_notification!(notification_id))
 
     updated_notifications =
       Enum.map(notifications, fn n ->
@@ -60,5 +53,12 @@ defmodule AppWeb.NotificationMenu do
      socket
      |> assign(:notifications, updated_notifications)
      |> assign(:displayed_notification, displayed_notification(updated_notifications))}
+  end
+
+  # Notifications with high importance are displayed in a in a prominent and intrusive way.
+  # We only display one notification at a time, and therefore we pick the first one which
+  # is not read yet.
+  defp displayed_notification(notifications) do
+    Enum.find(notifications, &(is_nil(&1.read_at) and &1.importance == :high))
   end
 end

--- a/apps/app_web/lib/app_web/components/notification_menu.ex
+++ b/apps/app_web/lib/app_web/components/notification_menu.ex
@@ -1,8 +1,23 @@
 defmodule AppWeb.NotificationMenu do
+  @moduledoc """
+  A component that renders the main notification menu.
+
+  The component is the main display point for notifications: give it a `:user`, it will
+  display their highly important notifications in a modal, but also mark them as read,
+  when they close it.
+
+  ## Attributes
+
+  - `:user` - the user to render the notifications for.
+
+  ## Examples
+
+      <.live_component module={AppWeb.NotificationMenu} id="notification-menu />
+
+  """
   use AppWeb, :live_component
 
   alias App.Notifications
-  alias App.Notifications.Notification
 
   @impl Phoenix.LiveComponent
   def update(assigns, socket) do

--- a/apps/app_web/lib/app_web/components/notification_menu.ex
+++ b/apps/app_web/lib/app_web/components/notification_menu.ex
@@ -1,0 +1,64 @@
+defmodule AppWeb.NotificationMenu do
+  use AppWeb, :live_component
+
+  alias App.Notifications
+  alias App.Notifications.Notification
+
+  @impl Phoenix.LiveComponent
+  def update(assigns, socket) do
+    notifications = Notifications.list_user_notifications(assigns.user)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:notifications, notifications)
+     |> assign(:displayed_notification, displayed_notification(notifications))}
+  end
+
+  # Notifications with high importance are displayed in a in a prominent and intrusive way.
+  # We only display one notification at a time, and therefore we pick the first one which
+  # is not read yet.
+  defp displayed_notification(notifications) do
+    Enum.find(notifications, &(is_nil(&1.read_at) and &1.importance == :high))
+  end
+
+  @impl Phoenix.LiveComponent
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.modal :if={@displayed_notification} id="notification-modal" open size={:xl}>
+        <%= @displayed_notification.content %>
+
+        <:footer>
+          <.button
+            color="feature"
+            phx-click="mark_as_read"
+            phx-target={@myself}
+            phx-value-id={@displayed_notification.id}
+          >
+            <%= gettext("Close") %>
+          </.button>
+        </:footer>
+      </.modal>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("mark_as_read", %{"id" => notification_id}, socket) do
+    %{user: user, notifications: notifications} = socket.assigns
+
+    {:ok, read_notification} =
+      Notifications.read_notification(user, %Notification{id: notification_id})
+
+    updated_notifications =
+      Enum.map(notifications, fn n ->
+        if n.id == read_notification.id, do: read_notification, else: n
+      end)
+
+    {:noreply,
+     socket
+     |> assign(:notifications, updated_notifications)
+     |> assign(:displayed_notification, displayed_notification(updated_notifications))}
+  end
+end

--- a/apps/app_web/lib/app_web/live/book_live/index.html.heex
+++ b/apps/app_web/lib/app_web/live/book_live/index.html.heex
@@ -1,5 +1,13 @@
 <.page_header>
   <:title><%= gettext("Books") %></:title>
+
+  <:menu>
+    <.live_component
+      module={AppWeb.NotificationMenu}
+      id="notification_viewer"
+      user={@current_user}
+    />
+  </:menu>
   <:menu>
     <.dropdown id="contextual-menu">
       <:toggle>

--- a/apps/app_web/lib/app_web/live/component_helpers.ex
+++ b/apps/app_web/lib/app_web/live/component_helpers.ex
@@ -370,6 +370,7 @@ defmodule AppWeb.ComponentHelpers do
 
   - id (required): The id of the modal
   - size: The size of the modal. Defaults to "md"
+  - open: Whether the modal is open by default or not. Defaults to false
 
   ## Slots
 
@@ -395,7 +396,10 @@ defmodule AppWeb.ComponentHelpers do
   """
   def modal(assigns) do
     ~H"""
-    <.focus_wrap id={@id} class={["modal", modal_size_class(assigns[:size])]}>
+    <.focus_wrap
+      id={@id}
+      class={["modal", modal_size_class(assigns[:size]), modal_open_class(assigns[:open])]}
+    >
       <section class="modal__dialog" role="dialog">
         <header class="modal__header">
           <%= render_slot(@header) %>
@@ -420,6 +424,9 @@ defmodule AppWeb.ComponentHelpers do
 
   defp modal_size_class(nil), do: "modal--md"
   defp modal_size_class(:xl), do: "modal--xl"
+
+  defp modal_open_class(nil), do: nil
+  defp modal_open_class(true), do: "modal--open"
 
   ## Toggle navigation
 

--- a/apps/app_web/lib/app_web/live/component_helpers.ex
+++ b/apps/app_web/lib/app_web/live/component_helpers.ex
@@ -401,7 +401,7 @@ defmodule AppWeb.ComponentHelpers do
       class={["modal", modal_size_class(assigns[:size]), modal_open_class(assigns[:open])]}
     >
       <section class="modal__dialog" role="dialog">
-        <header class="modal__header">
+        <header :if={assigns[:header]} class="modal__header">
           <%= render_slot(@header) %>
           <.button
             color="ghost"

--- a/apps/app_web/priv/gettext/default.pot
+++ b/apps/app_web/priv/gettext/default.pot
@@ -79,6 +79,10 @@ msgid "Change password"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "Close"
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "Confirm account"
 msgstr ""
 

--- a/apps/app_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/app_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -80,6 +80,10 @@ msgid "Change password"
 msgstr "Change password"
 
 #, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Close"
+
+#, elixir-autogen, elixir-format
 msgid "Confirm account"
 msgstr "Confirm account"
 


### PR DESCRIPTION
- style: update modal style a bit
- chore: allow rendering modals as `:open` by default
- feat: display high importance notifications in modal
- chore: fix `read_notifications/2` documentation
- chore: remove non-necessary `validate_inclusion/3` in changesets
- chore: make modal `:header` optional
- refactor: clean the code up a bit
- chore: alias `Phoenix.LiveView.JS` in view_helpers
