### PR TITLE
fix: correctly display page title

### DIFF
--- a/apps/app_web/lib/app_web/templates/layout/root.html.heex
+++ b/apps/app_web/lib/app_web/templates/layout/root.html.heex
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csrf-token" content={csrf_token_value()} />
-    <.live_title suffix=" · Anacounts">@page_title</.live_title>
+    <.live_title suffix=" · Anacounts"><%= @page_title %></.live_title>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")} />
     <script
       defer


### PR DESCRIPTION
Page title used not to work on non-live pages, and flash to `@page_title` on live ones
