### PR TITLE
chore: normalize naming of schema contexts functions

### DIFF
--- a/apps/app/lib/app/balance.ex
+++ b/apps/app/lib/app/balance.ex
@@ -50,7 +50,7 @@ defmodule App.Balance do
   end
 
   defp members_balance(book_id) do
-    transfers = Transfers.find_transfers_of_book(book_id)
+    transfers = Transfers.list_transfers_of_book(book_id)
 
     transfers
     |> Enum.flat_map(&balance_transfer_by_peer/1)
@@ -154,8 +154,8 @@ defmodule App.Balance do
 
   # --- Actual module content ---
 
-  @spec find_user_params(User.id()) :: [UserParams.t()]
-  def find_user_params(user_id) do
+  @spec list_user_params(User.id()) :: [UserParams.t()]
+  def list_user_params(user_id) do
     UserParams.base_query()
     |> UserParams.where_user_id(user_id)
     |> Repo.all()

--- a/apps/app/lib/app/balance.ex
+++ b/apps/app/lib/app/balance.ex
@@ -50,7 +50,7 @@ defmodule App.Balance do
   end
 
   defp members_balance(book_id) do
-    transfers = Transfers.find_transfers_in_book(book_id)
+    transfers = Transfers.find_transfers_of_book(book_id)
 
     transfers
     |> Enum.flat_map(&balance_transfer_by_peer/1)

--- a/apps/app/lib/app/balance/means/divide_equally.ex
+++ b/apps/app/lib/app/balance/means/divide_equally.ex
@@ -12,7 +12,7 @@ defmodule App.Balance.Means.DivideEqually do
 
   @impl App.Balance.Means
   def balance_transfer_by_peer(money_transfer) do
-    peers = Transfers.find_transfer_peers(money_transfer.id)
+    peers = Transfers.list_transfer_peers(money_transfer.id)
 
     transfer_amount = MoneyTransfer.amount(money_transfer)
     total_weight = Enum.reduce(peers, Decimal.new(0), &Decimal.add(&2, &1.weight))

--- a/apps/app/lib/app/balance/means/divide_equally.ex
+++ b/apps/app/lib/app/balance/means/divide_equally.ex
@@ -12,7 +12,7 @@ defmodule App.Balance.Means.DivideEqually do
 
   @impl App.Balance.Means
   def balance_transfer_by_peer(money_transfer) do
-    peers = Transfers.list_transfer_peers(money_transfer.id)
+    peers = Transfers.list_peers_of_transfer(money_transfer.id)
 
     transfer_amount = MoneyTransfer.amount(money_transfer)
     total_weight = Enum.reduce(peers, Decimal.new(0), &Decimal.add(&2, &1.weight))

--- a/apps/app/lib/app/books.ex
+++ b/apps/app/lib/app/books.ex
@@ -43,8 +43,8 @@ defmodule App.Books do
   @doc """
   Get all books of a specific user, whatever role they may have.
   """
-  @spec find_user_books(User.t()) :: [Book.t()]
-  def find_user_books(user) do
+  @spec list_user_books(User.t()) :: [Book.t()]
+  def list_user_books(user) do
     Book.user_query(user)
     |> Repo.all()
   end

--- a/apps/app/lib/app/books.ex
+++ b/apps/app/lib/app/books.ex
@@ -43,8 +43,8 @@ defmodule App.Books do
   @doc """
   Get all books of a specific user, whatever role they may have.
   """
-  @spec list_user_books(User.t()) :: [Book.t()]
-  def list_user_books(user) do
+  @spec list_books_of_user(User.t()) :: [Book.t()]
+  def list_books_of_user(user) do
     Book.user_query(user)
     |> Repo.all()
   end

--- a/apps/app/lib/app/notifications.ex
+++ b/apps/app/lib/app/notifications.ex
@@ -18,12 +18,12 @@ defmodule App.Notifications do
 
   ## Examples
 
-      iex> list_user_notifications()
+      iex> list_notifications_of_user()
       [%Notification{}, ...]
 
   """
-  @spec list_user_notifications(User.t()) :: [Notification.t()]
-  def list_user_notifications(%User{} = user) do
+  @spec list_notifications_of_user(User.t()) :: [Notification.t()]
+  def list_notifications_of_user(%User{} = user) do
     user_notifications_query(user.id)
     |> Repo.all()
   end

--- a/apps/app/lib/app/transfers.ex
+++ b/apps/app/lib/app/transfers.ex
@@ -154,8 +154,8 @@ defmodule App.Transfers do
 
   ## Peers
 
-  @spec list_transfer_peers(MoneyTransfer.id()) :: [Peer.t()]
-  def list_transfer_peers(transfer_id) do
+  @spec list_peers_of_transfer(MoneyTransfer.id()) :: [Peer.t()]
+  def list_peers_of_transfer(transfer_id) do
     Peer.base_query()
     |> Peer.where_transfer_id(transfer_id)
     |> Repo.all()

--- a/apps/app/lib/app/transfers.ex
+++ b/apps/app/lib/app/transfers.ex
@@ -47,6 +47,23 @@ defmodule App.Transfers do
     do: Repo.get_by!(MoneyTransfer, id: id, book_id: book_id)
 
   @doc """
+  Find all money transfers of a book.
+
+  ## Examples
+
+      iex> find_transfers_of_book(123)
+      [%MoneyTransfer{}, ...]
+
+  """
+  @spec find_transfers_of_book(Book.id()) :: [MoneyTransfer.t()]
+  def find_transfers_of_book(book_id) do
+    MoneyTransfer.base_query()
+    |> MoneyTransfer.where_book_id(book_id)
+    |> order_by(desc: :date)
+    |> Repo.all()
+  end
+
+  @doc """
   Creates a money_transfer.
 
   ## Examples
@@ -141,16 +158,6 @@ defmodule App.Transfers do
   def find_transfer_peers(transfer_id) do
     Peer.base_query()
     |> Peer.where_transfer_id(transfer_id)
-    |> Repo.all()
-  end
-
-  # TODO I don't know where to put this now
-
-  @spec find_transfers_in_book(Book.id()) :: [MoneyTransfer.t()]
-  def find_transfers_in_book(book_id) do
-    MoneyTransfer.base_query()
-    |> MoneyTransfer.where_book_id(book_id)
-    |> order_by(desc: :date)
     |> Repo.all()
   end
 end

--- a/apps/app/lib/app/transfers.ex
+++ b/apps/app/lib/app/transfers.ex
@@ -51,12 +51,12 @@ defmodule App.Transfers do
 
   ## Examples
 
-      iex> find_transfers_of_book(123)
+      iex> list_transfers_of_book(123)
       [%MoneyTransfer{}, ...]
 
   """
-  @spec find_transfers_of_book(Book.id()) :: [MoneyTransfer.t()]
-  def find_transfers_of_book(book_id) do
+  @spec list_transfers_of_book(Book.id()) :: [MoneyTransfer.t()]
+  def list_transfers_of_book(book_id) do
     MoneyTransfer.base_query()
     |> MoneyTransfer.where_book_id(book_id)
     |> order_by(desc: :date)
@@ -154,8 +154,8 @@ defmodule App.Transfers do
 
   ## Peers
 
-  @spec find_transfer_peers(MoneyTransfer.id()) :: [Peer.t()]
-  def find_transfer_peers(transfer_id) do
+  @spec list_transfer_peers(MoneyTransfer.id()) :: [Peer.t()]
+  def list_transfer_peers(transfer_id) do
     Peer.base_query()
     |> Peer.where_transfer_id(transfer_id)
     |> Repo.all()

--- a/apps/app/test/app/balance_test.exs
+++ b/apps/app/test/app/balance_test.exs
@@ -179,7 +179,7 @@ defmodule App.BalanceTest do
     setup :setup_balance_user_params_fixtures
 
     test "find user parameters for all codes", %{user: user} do
-      user_params = Balance.find_user_params(user.id)
+      user_params = Balance.list_user_params(user.id)
 
       assert length(user_params) == 1
 

--- a/apps/app/test/app/books_test.exs
+++ b/apps/app/test/app/books_test.exs
@@ -60,7 +60,7 @@ defmodule App.BooksTest do
       another_book = book_fixture(another_user, %{name: "Some other book from someone else"})
       _book_member = book_member_fixture(another_book, user)
 
-      user_books = Books.list_user_books(user)
+      user_books = Books.list_books_of_user(user)
       assert [book1, book2] = Enum.sort_by(user_books, & &1.id)
       assert book1.id == book.id
       assert book2.id == another_book.id

--- a/apps/app/test/app/books_test.exs
+++ b/apps/app/test/app/books_test.exs
@@ -60,7 +60,7 @@ defmodule App.BooksTest do
       another_book = book_fixture(another_user, %{name: "Some other book from someone else"})
       _book_member = book_member_fixture(another_book, user)
 
-      user_books = Books.find_user_books(user)
+      user_books = Books.list_user_books(user)
       assert [book1, book2] = Enum.sort_by(user_books, & &1.id)
       assert book1.id == book.id
       assert book2.id == another_book.id

--- a/apps/app/test/app/notifications_test.exs
+++ b/apps/app/test/app/notifications_test.exs
@@ -11,7 +11,7 @@ defmodule App.NotificationsTest do
   @valid_attrs %{title: "the title", content: "some content", type: :admin_announcement}
   @invalid_attrs %{title: "", content: nil, type: :none}
 
-  describe "list_user_notifications/1" do
+  describe "list_notifications_of_user/1" do
     test "returns all user notifications" do
       user = user_fixture()
       notification1 = notification_fixture([user])
@@ -19,7 +19,7 @@ defmodule App.NotificationsTest do
 
       _not_for_user = notification_fixture()
 
-      assert Notifications.list_user_notifications(user) == [notification1, notification2]
+      assert Notifications.list_notifications_of_user(user) == [notification1, notification2]
     end
   end
 

--- a/apps/app/test/app/transfers_test.exs
+++ b/apps/app/test/app/transfers_test.exs
@@ -20,7 +20,7 @@ defmodule App.TransfersTest do
     test "find all transfers in book", %{book: book, book_member: book_member} do
       transfer = money_transfer_fixture(book_id: book.id, tenant_id: book_member.id)
 
-      assert [found_transfer] = Transfers.find_transfers_of_book(book.id)
+      assert [found_transfer] = Transfers.list_transfers_of_book(book.id)
       assert found_transfer.id == transfer.id
     end
 
@@ -31,7 +31,7 @@ defmodule App.TransfersTest do
       transfer_before =
         money_transfer_fixture(book_id: book.id, tenant_id: book_member.id, date: ~D[2020-01-01])
 
-      assert [found_transfer1, found_transfer2] = Transfers.find_transfers_of_book(book.id)
+      assert [found_transfer1, found_transfer2] = Transfers.list_transfers_of_book(book.id)
       assert found_transfer1.id == transfer_after.id
       assert found_transfer2.id == transfer_before.id
     end

--- a/apps/app/test/app/transfers_test.exs
+++ b/apps/app/test/app/transfers_test.exs
@@ -12,7 +12,7 @@ defmodule App.TransfersTest do
   alias App.Balance.TransferParams
   alias App.Transfers
 
-  describe "find_transfers_in_book/1" do
+  describe "find_transfers_of_book/1" do
     setup :setup_user_fixture
     setup :setup_book_fixture
     setup :setup_book_member_fixture
@@ -20,7 +20,7 @@ defmodule App.TransfersTest do
     test "find all transfers in book", %{book: book, book_member: book_member} do
       transfer = money_transfer_fixture(book_id: book.id, tenant_id: book_member.id)
 
-      assert [found_transfer] = Transfers.find_transfers_in_book(book.id)
+      assert [found_transfer] = Transfers.find_transfers_of_book(book.id)
       assert found_transfer.id == transfer.id
     end
 
@@ -31,7 +31,7 @@ defmodule App.TransfersTest do
       transfer_before =
         money_transfer_fixture(book_id: book.id, tenant_id: book_member.id, date: ~D[2020-01-01])
 
-      assert [found_transfer1, found_transfer2] = Transfers.find_transfers_in_book(book.id)
+      assert [found_transfer1, found_transfer2] = Transfers.find_transfers_of_book(book.id)
       assert found_transfer1.id == transfer_after.id
       assert found_transfer2.id == transfer_before.id
     end

--- a/apps/app_web/lib/app_web/components/notification_menu.ex
+++ b/apps/app_web/lib/app_web/components/notification_menu.ex
@@ -21,7 +21,7 @@ defmodule AppWeb.NotificationMenu do
 
   @impl Phoenix.LiveComponent
   def update(assigns, socket) do
-    notifications = Notifications.list_user_notifications(assigns.user)
+    notifications = Notifications.list_notifications_of_user(assigns.user)
 
     {:ok,
      socket

--- a/apps/app_web/lib/app_web/controllers/user_settings_balance_controller.ex
+++ b/apps/app_web/lib/app_web/controllers/user_settings_balance_controller.ex
@@ -33,7 +33,7 @@ defmodule AppWeb.UserSettingsBalanceController do
   defp assign_changesets(conn, _opts) do
     # TODO There MUST be a better way to do this
     user_params =
-      Balance.find_user_params(conn.assigns.current_user.id)
+      Balance.list_user_params(conn.assigns.current_user.id)
       |> Enum.map(&Map.from_struct/1)
       |> Kernel.++(@default_user_params)
       |> Enum.uniq_by(& &1.means_code)

--- a/apps/app_web/lib/app_web/live/book_live/index.ex
+++ b/apps/app_web/lib/app_web/live/book_live/index.ex
@@ -11,7 +11,7 @@ defmodule AppWeb.BookLive.Index do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    books = Books.find_user_books(socket.assigns.current_user)
+    books = Books.list_user_books(socket.assigns.current_user)
     {:ok, assign(socket, :books, books)}
   end
 

--- a/apps/app_web/lib/app_web/live/book_live/index.ex
+++ b/apps/app_web/lib/app_web/live/book_live/index.ex
@@ -11,7 +11,7 @@ defmodule AppWeb.BookLive.Index do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    books = Books.list_user_books(socket.assigns.current_user)
+    books = Books.list_books_of_user(socket.assigns.current_user)
     {:ok, assign(socket, :books, books)}
   end
 

--- a/apps/app_web/lib/app_web/live/money_transfer_live/index.ex
+++ b/apps/app_web/lib/app_web/live/money_transfer_live/index.ex
@@ -15,7 +15,7 @@ defmodule AppWeb.MoneyTransferLive.Index do
 
     money_transfers =
       book_id
-      |> Transfers.find_transfers_in_book()
+      |> Transfers.find_transfers_of_book()
       # TODO No preload here
       |> App.Repo.preload(tenant: :user)
 

--- a/apps/app_web/lib/app_web/live/money_transfer_live/index.ex
+++ b/apps/app_web/lib/app_web/live/money_transfer_live/index.ex
@@ -15,7 +15,7 @@ defmodule AppWeb.MoneyTransferLive.Index do
 
     money_transfers =
       book_id
-      |> Transfers.find_transfers_of_book()
+      |> Transfers.list_transfers_of_book()
       # TODO No preload here
       |> App.Repo.preload(tenant: :user)
 


### PR DESCRIPTION
- chore: put `App.Transfers.find_transfers_in_book/1` where it belongs
- chore: rename `find_*` to `list_` functions
- chore: rename to list_<entity>_of_<owner>
