### PR TITLE
fix: hide functionalities based on member rights

### DIFF
--- a/apps/app/lib/app/books.ex
+++ b/apps/app/lib/app/books.ex
@@ -139,7 +139,7 @@ defmodule App.Books do
           {:ok, Book.t()} | {:error, Ecto.Changeset.t()} | {:error, :unauthorized}
   def update_book(book, user, attrs) do
     with %{} = member <- Members.get_membership(book.id, user.id),
-         true <- Rights.can_member_update_book?(member) do
+         true <- Rights.can_member_edit_book?(member) do
       book
       |> Book.changeset(attrs)
       |> Repo.update()

--- a/apps/app/lib/app/books.ex
+++ b/apps/app/lib/app/books.ex
@@ -139,7 +139,7 @@ defmodule App.Books do
           {:ok, Book.t()} | {:error, Ecto.Changeset.t()} | {:error, :unauthorized}
   def update_book(book, user, attrs) do
     with %{} = member <- Members.get_membership(book.id, user.id),
-         true <- Rights.member_can_update_book?(member) do
+         true <- Rights.can_member_update_book?(member) do
       book
       |> Book.changeset(attrs)
       |> Repo.update()
@@ -169,7 +169,7 @@ defmodule App.Books do
           {:ok, Book.t()} | {:error, Ecto.Changeset.t()} | {:error, :unauthorized}
   def delete_book(%Book{} = book, %User{} = user) do
     with %{} = member <- Members.get_membership(book.id, user.id),
-         true <- Rights.member_can_delete_book?(member) do
+         true <- Rights.can_member_delete_book?(member) do
       book
       |> Book.delete_changeset()
       |> Repo.update()

--- a/apps/app/lib/app/books/members.ex
+++ b/apps/app/lib/app/books/members.ex
@@ -40,7 +40,7 @@ defmodule App.Books.Members do
           {:ok, BookMember.t()} | {:error, Ecto.Changeset.t()} | {:error, :unauthorized}
   def invite_new_member(book_id, %User{} = user, user_email) do
     with %{} = member <- Members.get_membership(book_id, user.id),
-         true <- Rights.member_can_invite_new_member?(member) do
+         true <- Rights.can_member_invite_new_member?(member) do
       user =
         Auth.get_user_by_email(user_email) ||
           raise "User with email does not exist, crashing as inviting external people is not supported yet"

--- a/apps/app/lib/app/books/members.ex
+++ b/apps/app/lib/app/books/members.ex
@@ -10,7 +10,6 @@ defmodule App.Books.Members do
   alias App.Auth.User
   alias App.Books.Book
   alias App.Books.BookMember
-  alias App.Books.Members
   alias App.Books.Rights
 
   @doc """
@@ -39,7 +38,7 @@ defmodule App.Books.Members do
   @spec invite_new_member(Book.id(), User.t(), String.t()) ::
           {:ok, BookMember.t()} | {:error, Ecto.Changeset.t()} | {:error, :unauthorized}
   def invite_new_member(book_id, %User{} = user, user_email) do
-    with %{} = member <- Members.get_membership(book_id, user.id),
+    with %{} = member <- get_membership(book_id, user.id),
          true <- Rights.can_member_invite_new_member?(member) do
       user =
         Auth.get_user_by_email(user_email) ||
@@ -103,9 +102,29 @@ defmodule App.Books.Members do
       nil
 
   """
+  # TODO use entities instead of ids
   @spec get_membership(Book.id(), User.id()) :: BookMember.t() | nil
   def get_membership(book_id, user_id) do
     Repo.get_by(BookMember, book_id: book_id, user_id: user_id)
+  end
+
+  @doc """
+  Get the book member entity linking a user to a book.
+
+  Raises `Ecto.NoResultsError` if the user is not a member of the book.
+
+  ## Examples
+
+      iex> get_book_member_of_user!(book.id, user.id)
+      %BookMember{}
+
+      iex> get_book_member_of_user!(book.id, non_member_user.id)
+      ** (Ecto.NoResultsError)
+
+  """
+  @spec get_membership!(Book.t(), User.t()) :: BookMember.t() | nil
+  def get_membership!(%Book{} = book, %User{} = user) do
+    Repo.get_by(BookMember, book_id: book.id, user_id: user.id)
   end
 
   @doc """

--- a/apps/app/lib/app/books/rights.ex
+++ b/apps/app/lib/app/books/rights.ex
@@ -49,17 +49,17 @@ defmodule App.Books.Rights do
 
     ## Examples
 
-        iex> member_can_#{right}?(%BookMember{role: :creator})
+        iex> can_member_#{right}?(%BookMember{role: :creator})
         true
 
-        iex> member_can_#{right}?(%BookMember{role: :viewer})
+        iex> can_member_#{right}?(%BookMember{role: :viewer})
         false
 
     """
     # Credo: creating an atom from a string here is safe, as they are only created
     # at compile-time, from a list of known atoms.
     # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
-    def unquote(:"member_can_#{right}?")(member) do
+    def unquote(:"can_member_#{right}?")(member) do
       Role.has_right?(member.role, unquote(right))
     end
   end

--- a/apps/app/lib/app/books/rights.ex
+++ b/apps/app/lib/app/books/rights.ex
@@ -10,9 +10,9 @@ defmodule App.Books.Rights do
   ## Exhaustive list of rights
 
   - delete_book: Allow to delete a book
+  - edit_book: Allow to modify the book (e.g. name)
   - handle_money_transfers: Allow to create, update, and delete money transfers
   - invite_new_member: Allow to invite a new member in the book
-  - update_book: Allow to modify the book (e.g. name)
 
   """
 
@@ -20,15 +20,15 @@ defmodule App.Books.Rights do
 
   @type t ::
           :delete_book
+          | :edit_book
           | :handle_money_transfers
           | :invite_new_member
-          | :update_book
 
   @all_rights [
     :delete_book,
+    :edit_book,
     :handle_money_transfers,
-    :invite_new_member,
-    :update_book
+    :invite_new_member
   ]
 
   @creator_rights @all_rights

--- a/apps/app/lib/app/transfers.ex
+++ b/apps/app/lib/app/transfers.ex
@@ -181,7 +181,7 @@ defmodule App.Transfers do
 
   defp can_handle_transfers?(book_id, user_id) do
     if member = Members.get_membership(book_id, user_id),
-      do: Rights.member_can_handle_money_transfers?(member),
+      do: Rights.can_member_handle_money_transfers?(member),
       else: false
   end
 

--- a/apps/app/lib/app/transfers.ex
+++ b/apps/app/lib/app/transfers.ex
@@ -53,14 +53,14 @@ defmodule App.Transfers do
 
   ## Examples
 
-      iex> list_transfers_of_book(123)
+      iex> list_transfers_of_book(book)
       [%MoneyTransfer{}, ...]
 
   """
-  @spec list_transfers_of_book(Book.id()) :: [MoneyTransfer.t()]
-  def list_transfers_of_book(book_id) do
+  @spec list_transfers_of_book(Book.t()) :: [MoneyTransfer.t()]
+  def list_transfers_of_book(%Book{} = book) do
     base_query()
-    |> where_book_id(book_id)
+    |> where_book_id(book.id)
     |> order_by(desc: :date)
     |> Repo.all()
   end

--- a/apps/app/test/app/transfers_test.exs
+++ b/apps/app/test/app/transfers_test.exs
@@ -20,7 +20,7 @@ defmodule App.TransfersTest do
     test "find all transfers in book", %{book: book, member: member} do
       transfer = money_transfer_fixture(book, tenant_id: member.id)
 
-      assert [found_transfer] = Transfers.list_transfers_of_book(book.id)
+      assert [found_transfer] = Transfers.list_transfers_of_book(book)
       assert found_transfer.id == transfer.id
     end
 
@@ -29,7 +29,7 @@ defmodule App.TransfersTest do
 
       transfer_before = money_transfer_fixture(book, tenant_id: member.id, date: ~D[2020-01-01])
 
-      assert [found_transfer1, found_transfer2] = Transfers.list_transfers_of_book(book.id)
+      assert [found_transfer1, found_transfer2] = Transfers.list_transfers_of_book(book)
       assert found_transfer1.id == transfer_after.id
       assert found_transfer2.id == transfer_before.id
     end

--- a/apps/app_web/lib/app_web/book_access.ex
+++ b/apps/app_web/lib/app_web/book_access.ex
@@ -1,0 +1,42 @@
+defmodule AppWeb.BookAccess do
+  @moduledoc """
+  This module provides access checking for books.
+  """
+
+  alias App.Books
+  alias App.Books.Members
+
+  @doc """
+  * :ensure_book
+  Assigns `:book` and `:current_member` to the socket assigns based on the `"book_id"`
+  parameter if the current user is a member of the book.
+  Raises `Ecto.NoResultsError` if the book does not exist or the user is not a member.
+
+  ## Examples
+  # In a LiveView file
+  defmodule AppWeb.PageLive do
+    use AppWeb, :live_view
+
+    plug {AppWeb.BookAccess, :ensure_book!}
+
+  """
+  def on_mount(:ensure_book!, params, _session, socket) do
+    {:cont,
+     socket
+     |> mount_book!(params)
+     |> mount_current_member!()}
+  end
+
+  defp mount_book!(socket, %{"book_id" => book_id}) do
+    Phoenix.Component.assign_new(socket, :book, fn ->
+      Books.get_book!(book_id)
+    end)
+  end
+
+  defp mount_current_member!(socket) do
+    Phoenix.Component.assign_new(socket, :current_member, fn ->
+      %{book: book, current_user: current_user} = socket.assigns
+      Members.get_membership!(book, current_user)
+    end)
+  end
+end

--- a/apps/app_web/lib/app_web/live/balance_live/show.ex
+++ b/apps/app_web/lib/app_web/live/balance_live/show.ex
@@ -7,19 +7,19 @@ defmodule AppWeb.BalanceLive.Show do
   use AppWeb, :live_view
 
   alias App.Balance
-  alias App.Books
   alias App.Books.Members
 
+  on_mount {AppWeb.BookAccess, :ensure_book!}
+
   @impl Phoenix.LiveView
-  def mount(%{"book_id" => book_id}, _session, socket) do
-    book = Books.get_book_of_user!(book_id, socket.assigns.current_user)
+  def mount(_params, _session, socket) do
+    book = socket.assigns.book
 
     socket =
       socket
       |> assign(
         page_title: "Balance · #{book.name}",
-        layout_heading: gettext("Balance"),
-        book: book
+        layout_heading: gettext("Balance")
       )
       |> assign_transactions()
 

--- a/apps/app_web/lib/app_web/live/book_member_live/index.ex
+++ b/apps/app_web/lib/app_web/live/book_member_live/index.ex
@@ -10,20 +10,23 @@ defmodule AppWeb.BookMemberLive.Index do
   alias App.Balance
   alias App.Books
   alias App.Books.Members
+  alias App.Books.Rights
+
+  on_mount {AppWeb.BookAccess, :ensure_book!}
 
   @impl Phoenix.LiveView
-  def mount(%{"book_id" => book_id}, _session, socket) do
-    book = Books.get_book_of_user!(book_id, socket.assigns.current_user)
+  def mount(_params, _session, socket) do
+    book = socket.assigns.book
 
     members =
-      Members.list_members_of_book(book)
+      book
+      |> Members.list_members_of_book()
       |> Balance.fill_members_balance()
 
     socket =
       assign(socket,
         page_title: book.name,
         layout_heading: gettext("Details"),
-        book: book,
         members: members
       )
 

--- a/apps/app_web/lib/app_web/live/book_member_live/index.html.heex
+++ b/apps/app_web/lib/app_web/live/book_member_live/index.html.heex
@@ -1,5 +1,8 @@
 <div class="max-w-prose mx-auto">
-  <.tile navigate={Routes.invitation_index_path(@socket, :index, @book)}>
+  <.tile
+    :if={Rights.can_member_invite_new_member?(@current_member)}
+    navigate={Routes.invitation_index_path(@socket, :index, @book)}
+  >
     <.icon name="person-add" />
     <%= gettext("Invite member") %>
   </.tile>

--- a/apps/app_web/lib/app_web/live/invitation_live/index.ex
+++ b/apps/app_web/lib/app_web/live/invitation_live/index.ex
@@ -7,18 +7,18 @@ defmodule AppWeb.InvitationLive.Index do
   use AppWeb, :live_view
 
   alias App.Auth.Avatars
-  alias App.Books
   alias App.Books.Members
 
+  on_mount {AppWeb.BookAccess, :ensure_book!}
+
   @impl Phoenix.LiveView
-  def mount(%{"book_id" => book_id}, _session, socket) do
-    book = Books.get_book_of_user!(book_id, socket.assigns.current_user)
+  def mount(_params, _session, socket) do
+    book = socket.assigns.book
     members = Members.list_members_of_book(book)
 
     socket =
       assign(socket,
         page_title: gettext("Invitations · %{book_name}", book_name: book.name),
-        book: book,
         members: members
       )
 

--- a/apps/app_web/lib/app_web/live/money_transfer_live/form.ex
+++ b/apps/app_web/lib/app_web/live/money_transfer_live/form.ex
@@ -7,18 +7,19 @@ defmodule AppWeb.MoneyTransferLive.Form do
   use AppWeb, :live_view
 
   alias App.Auth.Avatars
-  alias App.Books
   alias App.Books.Members
   alias App.Transfers
   alias App.Transfers.MoneyTransfer
   alias App.Transfers.Peer
 
+  on_mount {AppWeb.BookAccess, :ensure_book!}
+
   @impl Phoenix.LiveView
-  def mount(%{"book_id" => book_id} = params, _session, socket) do
-    book = Books.get_book_of_user!(book_id, socket.assigns.current_user)
+  def mount(params, _session, socket) do
+    book = socket.assigns.book
     members = Members.list_members_of_book(book)
 
-    socket = assign(socket, book: book, members: members)
+    socket = assign(socket, members: members)
 
     {:ok, mount_action(socket, socket.assigns.live_action, params)}
   end

--- a/apps/app_web/lib/app_web/live/money_transfer_live/index.ex
+++ b/apps/app_web/lib/app_web/live/money_transfer_live/index.ex
@@ -6,15 +6,16 @@ defmodule AppWeb.MoneyTransferLive.Index do
 
   use AppWeb, :live_view
 
-  alias App.Books
   alias App.Transfers
 
+  on_mount {AppWeb.BookAccess, :ensure_book!}
+
   @impl Phoenix.LiveView
-  def mount(%{"book_id" => book_id}, _session, socket) do
-    book = Books.get_book_of_user!(book_id, socket.assigns.current_user)
+  def mount(_params, _session, socket) do
+    book = socket.assigns.book
 
     money_transfers =
-      book_id
+      book
       |> Transfers.list_transfers_of_book()
       |> Transfers.with_tenant()
 
@@ -22,7 +23,6 @@ defmodule AppWeb.MoneyTransferLive.Index do
       assign(socket,
         page_title: gettext("Transfers · %{book_name}", book_name: book.name),
         layout_heading: gettext("Transfers"),
-        book: book,
         money_transfers: money_transfers
       )
 

--- a/apps/app_web/lib/app_web/live/money_transfer_live/index.ex
+++ b/apps/app_web/lib/app_web/live/money_transfer_live/index.ex
@@ -6,6 +6,7 @@ defmodule AppWeb.MoneyTransferLive.Index do
 
   use AppWeb, :live_view
 
+  alias App.Books.Rights
   alias App.Transfers
 
   on_mount {AppWeb.BookAccess, :ensure_book!}

--- a/apps/app_web/lib/app_web/live/money_transfer_live/index.html.heex
+++ b/apps/app_web/lib/app_web/live/money_transfer_live/index.html.heex
@@ -24,10 +24,14 @@
       </div>
     </:description>
 
-    <:button navigate={Routes.money_transfer_form_path(@socket, :edit, @book, transfer)}>
+    <:button
+      :if={Rights.can_member_handle_money_transfers?(@current_member)}
+      navigate={Routes.money_transfer_form_path(@socket, :edit, @book, transfer)}
+    >
       <%= gettext("Edit") %>
     </:button>
     <:button
+      :if={Rights.can_member_handle_money_transfers?(@current_member)}
       class="text-error"
       data-confirm={gettext("Are you sure you want to delete the transfer?")}
       phx-click="delete"
@@ -39,7 +43,7 @@
 </div>
 
 <.fab_container class="mb-12 md:mb-0">
-  <:item>
+  <:item :if={Rights.can_member_handle_money_transfers?(@current_member)}>
     <.fab navigate={Routes.money_transfer_form_path(@socket, :new, @book)}>
       <.icon name="add" alt="Add a money transfer" />
     </.fab>

--- a/apps/app_web/lib/app_web/templates/layout/book.html.heex
+++ b/apps/app_web/lib/app_web/templates/layout/book.html.heex
@@ -23,18 +23,29 @@
     <%= gettext("Balance") %>
   </:tab_item>
 
-  <:menu>
+  <:menu :if={
+    Rights.can_member_edit_book?(@current_member) or
+      Rights.can_member_delete_book?(@current_member)
+  }>
     <.dropdown id="contextual-menu">
       <:toggle>
         <.icon name="more-vert" alt={gettext("Contextual menu")} size={:lg} />
       </:toggle>
 
-      <.list_item_link navigate={Routes.book_form_path(@socket, :edit, @book)} replace>
+      <.list_item_link
+        :if={Rights.can_member_edit_book?(@current_member)}
+        navigate={Routes.book_form_path(@socket, :edit, @book)}
+        replace
+      >
         <.icon name="edit" />
         <%= gettext("Edit") %>
       </.list_item_link>
-      <% # TODO Do not display the list item if the user is not allowed to delete the book %>
-      <.list_item_link id="delete-book" class="text-error" phx-click="delete">
+      <.list_item_link
+        :if={Rights.can_member_delete_book?(@current_member)}
+        id="delete-book"
+        class="text-error"
+        phx-click="delete"
+      >
         <.icon name="delete" />
         <%= gettext("Delete") %>
       </.list_item_link>

--- a/apps/app_web/lib/app_web/user_auth.ex
+++ b/apps/app_web/lib/app_web/user_auth.ex
@@ -117,12 +117,12 @@ defmodule AppWeb.UserAuth do
 
   @doc """
   # :mount_current_user:
-  Assigns current_user to socket assigns based on user_token.
+  Assigns `:current_user` to socket assigns based on user_token.
   Returns nil if there's no user_token or if there's no matching user.
 
   # :ensure_authenticated:
   Authenticates the user by looking into the session.
-  Assigns current_user to socket assigns based on user_token.
+  Assigns `:current_user` to socket assigns based on user_token.
   Redirects to login page if there's no logged user.
 
   ## Examples

--- a/apps/app_web/lib/app_web/views/layout_view.ex
+++ b/apps/app_web/lib/app_web/views/layout_view.ex
@@ -2,4 +2,5 @@ defmodule AppWeb.LayoutView do
   use AppWeb, :view
 
   alias App.Auth.Avatars
+  alias App.Books.Rights
 end


### PR DESCRIPTION
- chore: rename `member_can_*` to `can_member_*`
- chore: introduce new `BookAccess` module
- refactor: use new `BookAccess` module where relevant
- feat: hide functionalities based on `:current_member` rights
