### PR TITLE
chore: add balance_config.book_member_id

### DIFF
--- a/apps/app/lib/app/balance/balance_config.ex
+++ b/apps/app/lib/app/balance/balance_config.ex
@@ -14,7 +14,7 @@ defmodule App.Balance.BalanceConfig do
   @type t :: %__MODULE__{
           id: id(),
           annual_income: non_neg_integer(),
-          user: User.t() | Ecto.Association.NotLoaded.t(),
+          user: User.t(),
           user_id: User.id()
         }
 

--- a/apps/app/lib/app/balance/balance_config.ex
+++ b/apps/app/lib/app/balance/balance_config.ex
@@ -1,28 +1,44 @@
 defmodule App.Balance.BalanceConfig do
   @moduledoc """
-  The users configuration related to balancing.
+  The balance configuration of a user or a book member. This includes private data,
+  which is encrypted in the database.
 
-  This includes private data, which is encrypted in the database.
+  Each balance configuration is associated to either a user or a book member. When the
+  configuration is associated to a user, it represents the default configuration for
+  book members newly linked the user.
+
+  # Lifecycle (book members' configuration)
+
+  When a book member is created, a new empty balance configuration is created and
+  associated to them. If a user is associated to the book member, the configuration is
+  overriden with the user's default configuration.
+
   """
   use Ecto.Schema
   import Ecto.Changeset
 
   alias App.Auth.User
+  alias App.Books.BookMember
 
   @type id :: integer()
 
   @type t :: %__MODULE__{
           id: id(),
           annual_income: non_neg_integer(),
-          user: User.t(),
-          user_id: User.id()
+          user: User.t() | nil,
+          user_id: User.id() | nil,
+          book_member: BookMember.t() | nil,
+          book_member_id: BookMember.id() | nil
         }
 
   @derive {Inspect, only: [:id, :user, :user_id]}
   schema "balance_configs" do
     field :annual_income, App.Encrypted.Integer
 
+    # a balance config is associated to either a user or a book member, but not both
+    # see @moduledoc for more details
     belongs_to :user, User
+    belongs_to :book_member, BookMember
   end
 
   def changeset(struct, attrs) do
@@ -30,6 +46,7 @@ defmodule App.Balance.BalanceConfig do
     |> cast(attrs, [:annual_income])
     |> validate_annual_income()
     |> validate_user_id()
+    |> validate_book_member_id()
   end
 
   defp validate_annual_income(changeset) do
@@ -39,7 +56,11 @@ defmodule App.Balance.BalanceConfig do
 
   defp validate_user_id(changeset) do
     changeset
-    |> validate_required(:user_id)
     |> foreign_key_constraint(:user_id)
+  end
+
+  defp validate_book_member_id(changeset) do
+    changeset
+    |> foreign_key_constraint(:book_member_id)
   end
 end

--- a/apps/app/lib/app/balance/balance_config.ex
+++ b/apps/app/lib/app/balance/balance_config.ex
@@ -39,6 +39,8 @@ defmodule App.Balance.BalanceConfig do
     # see @moduledoc for more details
     belongs_to :user, User
     belongs_to :book_member, BookMember
+
+    timestamps()
   end
 
   def changeset(struct, attrs) do

--- a/apps/app/lib/app/notifications/notification.ex
+++ b/apps/app/lib/app/notifications/notification.ex
@@ -22,7 +22,7 @@ defmodule App.Notifications.Notification do
           id: id(),
           content: String.t(),
           type: type(),
-          recipients: [Recipient.t()] | Ecto.Association.NotLoaded.t(),
+          recipients: [Recipient.t()],
           inserted_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t()
         }

--- a/apps/app/lib/app/notifications/recipient.ex
+++ b/apps/app/lib/app/notifications/recipient.ex
@@ -14,9 +14,9 @@ defmodule App.Notifications.Recipient do
   @type t :: %__MODULE__{
           id: id(),
           notification_id: Notification.id(),
-          notification: Notification.t() | Ecto.Association.NotLoaded.t(),
+          notification: Notification.t(),
           user_id: User.id(),
-          user: User.t() | Ecto.Association.NotLoaded.t(),
+          user: User.t(),
           read_at: NaiveDateTime.t() | nil,
           inserted_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t()

--- a/apps/app/priv/repo/migrations/20230226110656_add_balance_config_book_member_id.exs
+++ b/apps/app/priv/repo/migrations/20230226110656_add_balance_config_book_member_id.exs
@@ -1,0 +1,18 @@
+defmodule App.Repo.Migrations.AddBalanceConfigBookMemberId do
+  use Ecto.Migration
+
+  def change do
+    alter table("balance_configs") do
+      add :book_member_id, references("book_members", on_delete: :delete_all)
+    end
+
+    create unique_index(:balance_configs, [:book_member_id])
+
+    execute "ALTER TABLE balance_configs ALTER COLUMN user_id DROP NOT NULL",
+            "ALTER TABLE balance_configs ALTER COLUMN user_id SET NOT NULL"
+
+    create constraint(:balance_configs, :either_user_or_book_member_id,
+             check: "num_nulls(user_id, book_member_id) = 1"
+           )
+  end
+end

--- a/apps/app/priv/repo/migrations/20230226122336_add_balance_configs_timestamps.exs
+++ b/apps/app/priv/repo/migrations/20230226122336_add_balance_configs_timestamps.exs
@@ -1,0 +1,20 @@
+defmodule App.Repo.Migrations.AddBalanceConfigsTimestamps do
+  use Ecto.Migration
+
+  def change do
+    alter table("balance_configs") do
+      timestamps(default: fragment("now()"))
+    end
+
+    execute """
+            ALTER TABLE balance_configs
+              ALTER COLUMN inserted_at DROP DEFAULT,
+              ALTER COLUMN updated_at DROP DEFAULT
+            """,
+            """
+            ALTER TABLE balance_configs
+              ALTER COLUMN inserted_at SET DEFAULT now(),
+              ALTER COLUMN updated_at SET DEFAULT now()
+            """
+  end
+end


### PR DESCRIPTION
- remove `Ecto.Association.NotLoaded.t()`
- add "balance_configs.book_member_id"
- add balance_configs timestamps
