### PR TITLE
chore: cleanup database schema

### DIFF
--- a/apps/app/lib/app/balance/balance_config.ex
+++ b/apps/app/lib/app/balance/balance_config.ex
@@ -107,11 +107,11 @@ defmodule App.Balance.BalanceConfig do
           updated_at: NaiveDateTime.t()
         }
 
-  @derive {Inspect, only: [:id]}
+  @derive {Inspect, only: [:id, :owner, :owner_id]}
   schema "balance_configs" do
     field :annual_income, App.Encrypted.Integer
 
-    belongs_to :owner, User, source: :user_id
+    belongs_to :owner, User
 
     timestamps()
   end

--- a/apps/app/priv/repo/migrations/20230402084640_rename_balance_configs_owner_id.exs
+++ b/apps/app/priv/repo/migrations/20230402084640_rename_balance_configs_owner_id.exs
@@ -1,0 +1,7 @@
+defmodule App.Repo.Migrations.RenameBalanceConfigsOwnerId do
+  use Ecto.Migration
+
+  def change do
+    rename table("balance_configs"), :user_id, to: :owner_id
+  end
+end

--- a/apps/app/priv/repo/migrations/20230402085652_make_users_balance_config_id_on_delete_restrict.exs
+++ b/apps/app/priv/repo/migrations/20230402085652_make_users_balance_config_id_on_delete_restrict.exs
@@ -1,0 +1,10 @@
+defmodule App.Repo.Migrations.MakeUsersBalanceConfigIdOnDeleteRestrict do
+  use Ecto.Migration
+
+  def change do
+    alter table("users") do
+      modify :balance_config_id, references("balance_configs", on_delete: :restrict),
+        from: references("balance_configs", on_delete: :nilify_all)
+    end
+  end
+end

--- a/apps/app/priv/repo/migrations/20230402090151_drop_balance_configs_book_member_id.exs
+++ b/apps/app/priv/repo/migrations/20230402090151_drop_balance_configs_book_member_id.exs
@@ -1,0 +1,9 @@
+defmodule App.Repo.Migrations.DropBalanceConfigsBookMemberId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:balance_configs) do
+      remove :book_member_id, references(:book_members, on_delete: :delete_all)
+    end
+  end
+end

--- a/apps/app/priv/repo/migrations/20230402090315_remove_balance_configs_owner_id_unique_constraint.exs
+++ b/apps/app/priv/repo/migrations/20230402090315_remove_balance_configs_owner_id_unique_constraint.exs
@@ -1,0 +1,15 @@
+defmodule App.Repo.Migrations.RemoveBalanceConfigsOwnerIdUniqueConstraint do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    drop unique_index(:balance_configs, [:owner_id],
+           name: "balance_configs_user_id_index",
+           concurrently: true
+         )
+
+    create index(:balance_configs, [:owner_id], concurrently: true)
+  end
+end

--- a/apps/app/priv/repo/migrations/20230402090616_rename_balance_config_owner_id_foreign_key.exs
+++ b/apps/app/priv/repo/migrations/20230402090616_rename_balance_config_owner_id_foreign_key.exs
@@ -1,0 +1,16 @@
+defmodule App.Repo.Migrations.RenameBalanceConfigOwnerIdForeignKey do
+  use Ecto.Migration
+
+  def change do
+    rename_constraint(
+      "balance_configs",
+      "balance_configs_user_id_fkey",
+      "balance_configs_owner_id_fkey"
+    )
+  end
+
+  defp rename_constraint(table, from, to) do
+    execute "ALTER TABLE #{table} RENAME CONSTRAINT #{from} TO #{to}",
+            "ALTER TABLE #{table} RENAME CONSTRAINT #{to} TO #{from}"
+  end
+end


### PR DESCRIPTION
- chore: rename `balance_configs.owner_id`
- chore: make users' balance_config_id "on delete restrict"
- chore: drop `balance_configs.book_member_id`
- chore: remove `balance_configs.owner_id` unique consraint
- chore: rename `balance_configs.owner_id` foreign key
