### PR TITLE
style: rename `Members.independent?/1`

### DIFF
--- a/apps/app/lib/app/books/members.ex
+++ b/apps/app/lib/app/books/members.ex
@@ -120,20 +120,19 @@ defmodule App.Books.Members do
   end
 
   @doc """
-  Check if a book member is yet to accept an invitation. In other words, a pending member
-  is not linked to a user yet. This means that if the user is invoved in a trasnfer using
-  a balance mean that required information about the user, the balance will fail.
+  Check if a book member is linked to a user.
 
   ## Examples
 
-      iex> pending?(book_member)
+      iex> independent?(book_member)
       true
 
-      iex> pending?(book_member_with_user)
+      iex> independent?(book_member_with_user)
       false
+
   """
-  @spec pending?(BookMember.t()) :: boolean()
-  def pending?(%BookMember{} = book_member) do
+  @spec independent?(BookMember.t()) :: boolean()
+  def independent?(%BookMember{} = book_member) do
     book_member.user_id == nil
   end
 

--- a/apps/app_web/lib/app_web/live/book_member_live/index.ex
+++ b/apps/app_web/lib/app_web/live/book_member_live/index.ex
@@ -23,14 +23,14 @@ defmodule AppWeb.BookMemberLive.Index do
       |> Members.list_members_of_book()
       |> Balance.fill_members_balance()
 
-    {pending_members, confirmed_members} = Enum.split_with(members, &Members.pending?/1)
+    {independent_members, linked_members} = Enum.split_with(members, &Members.independent?/1)
 
     socket =
       assign(socket,
         page_title: book.name,
         layout_heading: gettext("Details"),
-        confirmed_members: confirmed_members,
-        pending_members: pending_members
+        linked_members: linked_members,
+        independent_members: independent_members
       )
 
     {:ok, socket, layout: {AppWeb.Layouts, :book}}
@@ -96,7 +96,7 @@ defmodule AppWeb.BookMemberLive.Index do
   end
 
   defp member_status(assigns) do
-    if Members.pending?(assigns.member) do
+    if Members.independent?(assigns.member) do
       ~H"""
       <%= gettext("Invitation sent") %>
       <.icon name="pending" />

--- a/apps/app_web/lib/app_web/live/book_member_live/index.html.heex
+++ b/apps/app_web/lib/app_web/live/book_member_live/index.html.heex
@@ -7,11 +7,11 @@
     <%= gettext("Invite a new member") %>
   </.tile>
 
-  <.member_tile :for={member <- @confirmed_members} member={member} />
+  <.member_tile :for={member <- @linked_members} member={member} />
 
-  <.heading :if={not Enum.empty?(@pending_members)} level={:section} class="mt-6">
+  <.heading :if={not Enum.empty?(@independent_members)} level={:section} class="mt-6">
     <%= gettext("Pending members") %>
   </.heading>
 
-  <.member_tile :for={member <- @pending_members} member={member} />
+  <.member_tile :for={member <- @independent_members} member={member} />
 </div>


### PR DESCRIPTION
The independency of members does not have to do with whether they are pending an invitation or not. Reformulate, better naming