### PR TITLE
fix: do not replace peers when editing a transfer

### DIFF
--- a/apps/app_web/assets/css/base/form.css
+++ b/apps/app_web/assets/css/base/form.css
@@ -1,7 +1,7 @@
 @layer base {
   label {
     @apply block
-               mb-4;
+           mb-4;
   }
 
   input,
@@ -28,6 +28,7 @@
   }
 
   [type="checkbox"] {
-    @apply inline-block;
+    @apply inline-block
+           h-auto;
   }
 }

--- a/apps/app_web/lib/app_web/live/money_transfer_form_live.ex
+++ b/apps/app_web/lib/app_web/live/money_transfer_form_live.ex
@@ -126,6 +126,12 @@ defmodule AppWeb.MoneyTransferFormLive do
             <.list_item class="py-2">
               <input
                 type="hidden"
+                name={"money_transfer[peers][#{index}][id]"}
+                value={if peer, do: peer.id, else: nil}
+              />
+
+              <input
+                type="hidden"
                 name={"money_transfer[peers][#{index}][member_id]"}
                 value={member.id}
               />


### PR DESCRIPTION
- fix: adapt checkbox style
- test: add test verifying the peer isn't recreated
- fix: do not recreate a peer each time a transfer is edited
