### PR TITLE
chore: deprecate `BookMember.changeset/2`

### DIFF
--- a/apps/app/lib/app/balance/balance_configs.ex
+++ b/apps/app/lib/app/balance/balance_configs.ex
@@ -96,21 +96,12 @@ defmodule App.Balance.BalanceConfigs do
 
   @doc """
   Link a member to the user's balance configuration.
-
-  ## Examples
-
-      iex> link_user_balance_configs_to_member!(user, member)
-      :ok
-
-      iex> link_user_balance_configs_to_member!(user_without_config, member)
-      :ok
-
   """
   @spec link_user_balance_configs_to_member!(User.t(), BookMember.t()) :: :ok
   def link_user_balance_configs_to_member!(user, member) do
-    member
-    |> BookMember.balance_config_changeset(%{balance_config_id: user.balance_config_id})
-    |> Repo.update!()
+    {1, nil} =
+      from(BookMember, where: [id: ^member.id])
+      |> Repo.update_all(set: [balance_config_id: user.balance_config_id])
 
     :ok
   end

--- a/apps/app/lib/app/books/book_member.ex
+++ b/apps/app/lib/app/books/book_member.ex
@@ -101,21 +101,6 @@ defmodule App.Books.BookMember do
     |> validate_length(:nickname, min: 1, max: 255)
   end
 
-  @doc """
-  Changeset for updating the balance config of a book member.
-  """
-  @spec balance_config_changeset(t(), map()) :: Ecto.Changeset.t()
-  def balance_config_changeset(struct, attrs) do
-    struct
-    |> cast(attrs, [:balance_config_id])
-    |> validate_balance_config_id()
-  end
-
-  defp validate_balance_config_id(changeset) do
-    changeset
-    |> foreign_key_constraint(:balance_config_id)
-  end
-
   ## Queries
 
   @doc """

--- a/apps/app/lib/app/books/book_member.ex
+++ b/apps/app/lib/app/books/book_member.ex
@@ -63,7 +63,10 @@ defmodule App.Books.BookMember do
 
   ## Changeset
 
-  def changeset(struct, attrs) do
+  # Most of the validations done here are useless, unexpected wrong values should
+  # be caught by the database and make the process crash
+  # TODO use a simpler changeset, validating only what can be changed in interfaces
+  def deprecated_changeset(struct, attrs) do
     struct
     |> cast(attrs, [:user_id, :role, :nickname])
     |> validate_book_id()

--- a/apps/app/lib/app/books/members.ex
+++ b/apps/app/lib/app/books/members.ex
@@ -141,7 +141,7 @@ defmodule App.Books.Members do
   def create_book_member(%Book{} = book, attrs) do
     %BookMember{book_id: book.id}
     # set the member role as default, it can be changed later
-    |> BookMember.changeset(attrs)
+    |> BookMember.deprecated_changeset(attrs)
     |> Repo.insert()
   end
 
@@ -190,7 +190,7 @@ defmodule App.Books.Members do
   def accept_invitation(%BookMember{user_id: nil} = book_member, %User{} = user) do
     {:ok, %{book_member: book_member}} =
       Ecto.Multi.new()
-      |> Ecto.Multi.update(:book_member, BookMember.changeset(book_member, %{user_id: user.id}))
+      |> Ecto.Multi.update(:book_member, BookMember.deprecated_changeset(book_member, %{user_id: user.id}))
       |> link_user_balance_configs_multi(user)
       |> maybe_try_to_delete_balance_config_multi(book_member.balance_config_id)
       |> Ecto.Multi.delete_all(
@@ -230,6 +230,6 @@ defmodule App.Books.Members do
   """
   @spec change_book_member(BookMember.t(), map()) :: Ecto.Changeset.t(BookMember.t())
   def change_book_member(book_member, attrs \\ %{}) do
-    BookMember.changeset(book_member, attrs)
+    BookMember.deprecated_changeset(book_member, attrs)
   end
 end

--- a/apps/app/test/app/books/book_member_test.exs
+++ b/apps/app/test/app/books/book_member_test.exs
@@ -10,10 +10,10 @@ defmodule App.Books.BookMemberTest do
     %{book: book_fixture()}
   end
 
-  describe "changeset/2" do
+  describe "deprecated_changeset/2" do
     test "does not change the `:book_id`", %{book: book} do
       book_member = book_member_fixture(book)
-      changeset = BookMember.changeset(book_member, %{book_id: 1})
+      changeset = BookMember.deprecated_changeset(book_member, %{book_id: 1})
 
       assert changeset.valid?
       assert changeset.changes == %{}
@@ -21,7 +21,7 @@ defmodule App.Books.BookMemberTest do
 
     test "does not change the `:balance_config_id`", %{book: book} do
       book_member = book_member_fixture(book)
-      changeset = BookMember.changeset(book_member, %{balance_config_id: 1})
+      changeset = BookMember.deprecated_changeset(book_member, %{balance_config_id: 1})
 
       assert changeset.valid?
       assert changeset.changes == %{}

--- a/apps/app/test/app/books/book_member_test.exs
+++ b/apps/app/test/app/books/book_member_test.exs
@@ -27,29 +27,4 @@ defmodule App.Books.BookMemberTest do
       assert changeset.changes == %{}
     end
   end
-
-  describe "balance_config_changeset/2" do
-    test "changes the `:balance_config_id`", %{book: book} do
-      book_member = book_member_fixture(book)
-      changeset = BookMember.balance_config_changeset(book_member, %{balance_config_id: 1})
-
-      assert changeset.valid?
-      assert changeset.changes == %{balance_config_id: 1}
-    end
-
-    test "does not change other fields", %{book: book} do
-      book_member = book_member_fixture(book)
-
-      changeset =
-        BookMember.balance_config_changeset(book_member, %{
-          book_id: 1,
-          user_id: 1,
-          role: :viewer,
-          nickname: "New nickname"
-        })
-
-      assert changeset.valid?
-      assert changeset.changes == %{}
-    end
-  end
 end

--- a/apps/app/test/app/books/members_test.exs
+++ b/apps/app/test/app/books/members_test.exs
@@ -173,7 +173,9 @@ defmodule App.Books.MembersTest do
     end
 
     test "links the user to the book member", %{book_member: book_member, user: user} do
-      assert {:ok, book_member} = Members.accept_invitation(book_member, user)
+      :ok = Members.accept_invitation(book_member, user)
+
+      book_member = Repo.reload(book_member)
       assert book_member.user_id == user.id
       assert book_member.balance_config_id == nil
     end
@@ -185,8 +187,10 @@ defmodule App.Books.MembersTest do
       user_balance_config = user_balance_config_fixture(user)
       user = Repo.reload(user)
 
-      assert {:ok, book_member} = Members.accept_invitation(book_member, user)
-      assert Repo.reload(book_member).balance_config_id == user_balance_config.id
+      :ok = Members.accept_invitation(book_member, user)
+
+      book_member = Repo.reload(book_member)
+      assert book_member.balance_config_id == user_balance_config.id
     end
 
     # TODO
@@ -200,7 +204,7 @@ defmodule App.Books.MembersTest do
       member_balance_config = member_balance_config_fixture(book_member)
       book_member = Repo.reload(book_member)
 
-      assert {:ok, _book_member} = Members.accept_invitation(book_member, user)
+      :ok = Members.accept_invitation(book_member, user)
 
       refute Repo.get(BalanceConfig, member_balance_config.id)
     end
@@ -219,7 +223,7 @@ defmodule App.Books.MembersTest do
       other_book_member = book_member_fixture(book_fixture())
       member_balance_config_link_fixture(other_book_member, member_balance_config)
 
-      assert {:ok, _book_member} = Members.accept_invitation(book_member, user)
+      :ok = Members.accept_invitation(book_member, user)
 
       assert Repo.get(BalanceConfig, member_balance_config.id)
     end
@@ -239,7 +243,7 @@ defmodule App.Books.MembersTest do
           Members.deliver_invitation(book_member, user.email, url)
         end)
 
-      assert {:ok, _book_member} = Members.accept_invitation(book_member, user)
+      :ok = Members.accept_invitation(book_member, user)
 
       {:ok, decoded_token} = Base.url_decode64(token, padding: false)
       refute Repo.get_by(InvitationToken, token: :crypto.hash(:sha256, decoded_token))

--- a/apps/app_web/lib/app_web/controllers/book_invitation_controller.ex
+++ b/apps/app_web/lib/app_web/controllers/book_invitation_controller.ex
@@ -30,7 +30,7 @@ defmodule AppWeb.BookInvitationController do
   def update(conn, _opts) do
     %{book_member: book_member, current_user: current_user} = conn.assigns
 
-    {:ok, _book_member} = Members.accept_invitation(book_member, current_user)
+    Members.accept_invitation(book_member, current_user)
 
     conn
     |> put_flash(:info, gettext("You have been added to the book."))


### PR DESCRIPTION
- chore: rename `BookMember.deprecated_changeset/2`
- refactor: remove easily replaceable usages
- chore: remove `BookMember.balance_config_changeset/2`
