### PR TITLE
chore: make Sentry config general

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -66,8 +66,23 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-# Use Finch as Sentry's HTTP client
-config :sentry, client: Sentry.FinchClient
+# ## Error reporting
+#
+# Configure errors to be reported to Sentry. Requires to call `plug Sentry.PlugContext`
+# in the Endpoint.
+# According to the Sentry documentation, the `:dsn` is "safe to keep public because they
+# only allow submission of new events and related event data; they do not allow read
+# access to any information".
+#
+# See the documentation of `:sentry` for more information.
+
+config :sentry,
+  dsn: "https://001afba5be1f4c968de015c2fc051cd9@o1240316.ingest.sentry.io/6392357",
+  environment_name: Mix.env(),
+  included_environments: [:prod],
+  client: Sentry.FinchClient,
+  enable_source_code_context: true,
+  root_source_code_path: File.cwd!()
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,28 +17,5 @@ config :swoosh, :api_client, Swoosh.ApiClient.Finch
 # Do not print debug messages in production
 config :logger, level: :info
 
-# ## Error reporting
-#
-# Configure errors to be reported to Sentry. Requires to call `plug Sentry.PlugContext`
-# in the Endpoint.
-# According to the Sentry documentation, the `:dsn` is "safe to keep public because they
-# only allow submission of new events and related event data; they do not allow read
-# access to any information".
-#
-# See the documentation of `:sentry` for more information.
-
-config :sentry,
-  dsn: "https://001afba5be1f4c968de015c2fc051cd9@o1240316.ingest.sentry.io/6392357",
-  environment_name: :prod,
-  enable_source_code_context: true,
-  root_source_code_path: File.cwd!(),
-  tags: %{
-    env: "production"
-  },
-  included_environments: [:prod]
-
-config :logger,
-  backends: [:console, Sentry.LoggerBackend]
-
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.


### PR DESCRIPTION
`mix test` displayed some warning because of Sentry.
Sentry indeed needs to be configured in all environments, although non-prod environments are not included