### PR TITLE
chore: create Postgres enum for "money_transfers"."type"

### DIFF
--- a/apps/app/priv/repo/migrations/20230910155943_create_transfers_type_enum.exs
+++ b/apps/app/priv/repo/migrations/20230910155943_create_transfers_type_enum.exs
@@ -1,0 +1,17 @@
+defmodule App.Repo.Migrations.CreateTransfersTypeEnum do
+  use Ecto.Migration
+
+  def change do
+    execute "CREATE TYPE money_transfers_type AS ENUM ('payment', 'income', 'reimbursement')",
+            "DROP TYPE money_transfers_type"
+
+    execute """
+            ALTER TABLE money_transfers
+            ALTER COLUMN type TYPE money_transfers_type USING type::money_transfers_type
+            """,
+            """
+            ALTER TABLE money_transfers
+            ALTER COLUMN type TYPE varchar USING type::varchar
+            """
+  end
+end


### PR DESCRIPTION
Only the enum `MoneyTransfer.type` Ecto.Enum didn't have a matching Postgres enum
Closes #17