### PR TITLE
fix: make header sticky

### DIFF
--- a/apps/app_web/lib/app_web/components/page_components.ex
+++ b/apps/app_web/lib/app_web/components/page_components.ex
@@ -160,7 +160,8 @@ defmodule AppWeb.PageComponents do
   """
   def page_header(assigns) do
     ~H"""
-    <header class="flex items-center gap-2
+    <header class="sticky top-0
+                   flex items-center gap-2
                    h-14 mb-2 px-4
                    bg-theme text-white shadow">
       <.button


### PR DESCRIPTION
The header currently disappears after scrolling on pages.
Make it sticky to prevent that