### PR TITLE
refactor: simplify page_header's title

### DIFF
--- a/apps/app_web/assets/css/components/heading.css
+++ b/apps/app_web/assets/css/components/heading.css
@@ -3,11 +3,6 @@
     @apply truncate;
   }
 
-  .heading--title {
-    @apply uppercase;
-    font-size: clamp(1.25rem, -1rem + 8.333vw, 1.5rem);
-  }
-
   .heading--section {
     @apply mx-4
            font-bold uppercase;

--- a/apps/app_web/lib/app_web/components/core_components.ex
+++ b/apps/app_web/lib/app_web/components/core_components.ex
@@ -373,17 +373,13 @@ defmodule AppWeb.CoreComponents do
 
   ## Examples
 
-      <.heading level={:title}>
-        Title
-      </.heading>
-
       <.heading level={:section}>
         Section title
       </.heading>
 
   """
 
-  attr :level, :atom, required: true, values: [:title, :section], doc: "The level of the heading"
+  attr :level, :atom, required: true, values: [:section], doc: "The level of the heading"
   attr :class, :any, default: nil, doc: "Extra classes to add to the heading"
   attr :rest, :global
 
@@ -401,10 +397,8 @@ defmodule AppWeb.CoreComponents do
     """
   end
 
-  defp heading_level_tag(:title), do: "h1"
   defp heading_level_tag(:section), do: "h2"
 
-  defp heading_level_class(:title), do: "heading--title"
   defp heading_level_class(:section), do: "heading--section"
 
   ## Icon
@@ -507,7 +501,7 @@ defmodule AppWeb.CoreComponents do
 
       <.modal id="modal">
         <:header>
-          <.heading level={:title}>Modal title</.heading>
+          <h1>Modal title</h1>
         </:header>
 
         <p>Modal body</p>

--- a/apps/app_web/lib/app_web/components/page_components.ex
+++ b/apps/app_web/lib/app_web/components/page_components.ex
@@ -171,7 +171,9 @@ defmodule AppWeb.PageComponents do
         <.icon name="arrow-back" alt={gettext("Go back")} />
       </.button>
 
-      <.heading level={:title} class="mr-auto"><%= render_slot(@title) %></.heading>
+      <b class="mr-auto text-xl md:text-2xl font-normal uppercase">
+        <%= render_slot(@title) %>
+      </b>
 
       <.tabs :if={not is_nil(assigns[:tab_item]) and not Enum.empty?(@tab_item)}>
         <:item :for={tab_item <- @tab_item} {assigns_to_attributes(tab_item)}>

--- a/apps/app_web/test/app_web/live/book_members_live_test.exs
+++ b/apps/app_web/test/app_web/live/book_members_live_test.exs
@@ -29,7 +29,7 @@ defmodule AppWeb.BookMembersLiveTest do
     {:ok, _live, html} = live(conn, ~p"/books/#{book}/members")
 
     # the book name is the main title
-    assert html =~ book.name <> "\n</h1>"
+    assert html =~ book.name <> "\n  </b>"
     # the tabs are displayed
     assert html =~ "Members"
     # there are links that go to the invitation and member creation pages


### PR DESCRIPTION
- fix: simplify page_header title
- chore: remove unused heading level `:title`
