### PR TITLE
fix: correctly divide amounts among peers

### DIFF
--- a/apps/app/lib/app/balance.ex
+++ b/apps/app/lib/app/balance.ex
@@ -29,7 +29,6 @@ defmodule App.Balance do
     members
     |> reset_members_balance()
     |> adjust_balance_from_transfers(transfers)
-    |> round_members_balance()
   end
 
   # Preload peers of transfers and fill their `:member` field.
@@ -58,13 +57,27 @@ defmodule App.Balance do
     |> Enum.flat_map(&compute_peers_total_weight/1)
     |> Enum.map(fn
       {:ok, transfer} ->
-        total_peer_weight =
-          Enum.reduce(transfer.peers, Decimal.new(0), &Decimal.add(&2, &1.total_weight))
+        peers = normalize_peers_total_weight(transfer.peers)
+        total_peer_weight = peers |> Enum.map(& &1.total_weight) |> Enum.sum()
 
-        {:ok, %{transfer | total_peer_weight: total_peer_weight}}
+        {:ok, %{transfer | peers: peers, total_peer_weight: total_peer_weight}}
 
       {:error, _reasons, _transfer} = error ->
         error
+    end)
+  end
+
+  defp normalize_peers_total_weight(peers) do
+    # The weight and total weight need to be integers for the algorithm to work,
+    # find the max scale (= number of digits after the decimal point) of all peers
+    # and multiply all weights by 10^max_scale to convert them to integers.
+    max_scale = peers |> Stream.map(&Decimal.scale(&1.total_weight)) |> Enum.max()
+
+    Enum.map(peers, fn peer ->
+      # Fiddling with Decimal internals. The value of a decimal is `:sign * :coef * 10 ^ :exp`
+      # so adding x to the exponent is equivalent to multiplying by 10^x.
+      int_total_weight = Map.update!(peer.total_weight, :exp, &(&1 + max_scale))
+      %{peer | total_weight: Decimal.to_integer(int_total_weight)}
     end)
   end
 
@@ -128,8 +141,11 @@ defmodule App.Balance do
   defp adjust_balance_from_transfers(members, []), do: members
 
   defp adjust_balance_from_transfers(members, [{:ok, transfer} | other_transfers]) do
+    transfer_amount = Transfers.amount(transfer)
+    amounts = Money.split(transfer_amount, transfer.total_peer_weight)
+
     members
-    |> adjust_balance_from_peers(transfer, transfer.peers)
+    |> adjust_balance_from_peers(transfer, transfer.peers, amounts)
     |> adjust_balance_from_transfers(other_transfers)
   end
 
@@ -139,16 +155,19 @@ defmodule App.Balance do
     |> adjust_balance_from_transfers(other_transfers)
   end
 
-  defp adjust_balance_from_peers(members, _transfer, []), do: members
+  defp adjust_balance_from_peers(members, _transfer, [], _amounts), do: members
 
-  defp adjust_balance_from_peers(members, %{tenant_id: id} = transfer, [%{member_id: id} | peers]) do
-    adjust_balance_from_peers(members, transfer, peers)
+  defp adjust_balance_from_peers(
+         members,
+         %{tenant_id: id} = transfer,
+         [%{member_id: id} | peers],
+         amounts
+       ) do
+    adjust_balance_from_peers(members, transfer, peers, amounts)
   end
 
-  defp adjust_balance_from_peers(members, transfer, [peer | other_peers]) do
-    relative_weight = Decimal.div(peer.total_weight, transfer.total_peer_weight)
-    transfer_amount = Transfers.amount(transfer)
-    adjustment_amount = Money.mult!(transfer_amount, relative_weight)
+  defp adjust_balance_from_peers(members, transfer, [peer | other_peers], amounts) do
+    adjustment_amount = adjustment_amount(peer, other_peers, amounts)
 
     member_id = peer.member_id
     tenant_id = transfer.tenant_id
@@ -168,7 +187,18 @@ defmodule App.Balance do
       member ->
         member
     end)
-    |> adjust_balance_from_peers(transfer, other_peers)
+    |> adjust_balance_from_peers(transfer, other_peers, amounts)
+  end
+
+  # Add the remaining amount to the last peer
+  defp adjustment_amount(peer, [], {split_amount, remaining_amount}) do
+    split_amount
+    |> Money.mult!(peer.total_weight)
+    |> Money.add!(remaining_amount)
+  end
+
+  defp adjustment_amount(peer, _other_peers, {split_amount, _remaining_amount}) do
+    Money.mult!(split_amount, peer.total_weight)
   end
 
   defp add_balance_errors_on_members_in_transfer(members, reasons, transfer) do
@@ -190,14 +220,6 @@ defmodule App.Balance do
       end
 
     %{member | balance: {:error, reasons}}
-  end
-
-  defp round_members_balance(members) do
-    Enum.map(members, fn member ->
-      if has_balance_error?(member),
-        do: member,
-        else: %{member | balance: Money.round(member.balance)}
-    end)
   end
 
   @doc """

--- a/apps/app/lib/app/transfers/money_transfer.ex
+++ b/apps/app/lib/app/transfers/money_transfer.ex
@@ -24,7 +24,7 @@ defmodule App.Transfers.MoneyTransfer do
           book: Book.t(),
           tenant: BookMember.t(),
           balance_params: TransferParams.t(),
-          peers: Peer.t(),
+          peers: [Peer.t()],
           total_peer_weight: Decimal.t(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()

--- a/apps/app/test/app/balance_test.exs
+++ b/apps/app/test/app/balance_test.exs
@@ -1,7 +1,6 @@
 defmodule App.BalanceTest do
   use App.DataCase, async: true
 
-  import App.AccountsFixtures
   import App.Balance.BalanceConfigsFixtures
   import App.Books.MembersFixtures
   import App.BooksFixtures
@@ -15,8 +14,8 @@ defmodule App.BalanceTest do
     end
 
     test "balances transfers correctly", %{book: book} do
-      member1 = book_member_fixture(book, user_id: user_fixture().id)
-      member2 = book_member_fixture(book, user_id: user_fixture().id)
+      member1 = book_member_fixture(book)
+      member2 = book_member_fixture(book)
 
       _money_transfer =
         deprecated_money_transfer_fixture(book,
@@ -31,10 +30,10 @@ defmodule App.BalanceTest do
     end
 
     test "balances multiple transfers correctly #1", %{book: book} do
-      member1 = book_member_fixture(book, user_id: user_fixture().id)
-      member2 = book_member_fixture(book, user_id: user_fixture().id)
-      member3 = book_member_fixture(book, user_id: user_fixture().id)
-      member4 = book_member_fixture(book, user_id: user_fixture().id)
+      member1 = book_member_fixture(book)
+      member2 = book_member_fixture(book)
+      member3 = book_member_fixture(book)
+      member4 = book_member_fixture(book)
 
       _transfer1 =
         deprecated_money_transfer_fixture(book,
@@ -70,9 +69,9 @@ defmodule App.BalanceTest do
     end
 
     test "balances multiple transfers correctly #2", %{book: book} do
-      member1 = book_member_fixture(book, user_id: user_fixture().id)
-      member2 = book_member_fixture(book, user_id: user_fixture().id)
-      member3 = book_member_fixture(book, user_id: user_fixture().id)
+      member1 = book_member_fixture(book)
+      member2 = book_member_fixture(book)
+      member3 = book_member_fixture(book)
 
       _transfer1 =
         deprecated_money_transfer_fixture(book,
@@ -103,9 +102,9 @@ defmodule App.BalanceTest do
     end
 
     test "takes peer weight into account", %{book: book} do
-      member1 = book_member_fixture(book, user_id: user_fixture().id)
-      member2 = book_member_fixture(book, user_id: user_fixture().id)
-      member3 = book_member_fixture(book, user_id: user_fixture().id)
+      member1 = book_member_fixture(book)
+      member2 = book_member_fixture(book)
+      member3 = book_member_fixture(book)
 
       _transfer =
         deprecated_money_transfer_fixture(book,
@@ -125,8 +124,8 @@ defmodule App.BalanceTest do
     end
 
     test "correctly divide non round amounts", %{book: book} do
-      member1 = book_member_fixture(book, user_id: user_fixture().id)
-      member2 = book_member_fixture(book, user_id: user_fixture().id)
+      member1 = book_member_fixture(book)
+      member2 = book_member_fixture(book)
 
       _transfer =
         deprecated_money_transfer_fixture(book,
@@ -275,9 +274,9 @@ defmodule App.BalanceTest do
     end
 
     test "does not crash if the book is correctly balanced", %{book: book} do
-      member1 = book_member_fixture(book, user_id: user_fixture().id)
-      member2 = book_member_fixture(book, user_id: user_fixture().id)
-      member3 = book_member_fixture(book, user_id: user_fixture().id)
+      member1 = book_member_fixture(book)
+      member2 = book_member_fixture(book)
+      member3 = book_member_fixture(book)
 
       _transfer1 =
         deprecated_money_transfer_fixture(book,
@@ -319,14 +318,9 @@ defmodule App.BalanceTest do
     end
 
     test "creates transactions to balance members money #1", %{book: book} do
-      member1 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, 10))
-
-      member2 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, -10))
-
-      member3 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, 0))
+      member1 = book_member_fixture(book, balance: Money.new!(:EUR, 10))
+      member2 = book_member_fixture(book, balance: Money.new!(:EUR, -10))
+      member3 = book_member_fixture(book, balance: Money.new!(:EUR, 0))
 
       assert {:ok, transactions} = Balance.transactions([member1, member2, member3])
 
@@ -341,20 +335,11 @@ defmodule App.BalanceTest do
     end
 
     test "creates transactions to balance members money #2", %{book: book} do
-      member1 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, 120))
-
-      member2 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, 33))
-
-      member3 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, -12))
-
-      member4 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, -121))
-
-      member5 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, -20))
+      member1 = book_member_fixture(book, balance: Money.new!(:EUR, 120))
+      member2 = book_member_fixture(book, balance: Money.new!(:EUR, 33))
+      member3 = book_member_fixture(book, balance: Money.new!(:EUR, -12))
+      member4 = book_member_fixture(book, balance: Money.new!(:EUR, -121))
+      member5 = book_member_fixture(book, balance: Money.new!(:EUR, -20))
 
       assert {:ok, transactions} =
                Balance.transactions([member1, member2, member3, member4, member5])
@@ -392,14 +377,8 @@ defmodule App.BalanceTest do
     end
 
     test "returns :error when the balance of a member is corrupted", %{book: book} do
-      member1 =
-        book_member_fixture(book, user_id: user_fixture().id, balance: Money.new!(:EUR, 10))
-
-      member2 =
-        book_member_fixture(book,
-          user_id: user_fixture().id,
-          balance: {:error, ["could not compute balance"]}
-        )
+      member1 = book_member_fixture(book, balance: Money.new!(:EUR, 10))
+      member2 = book_member_fixture(book, balance: {:error, ["could not compute balance"]})
 
       assert Balance.transactions([member1, member2]) == {:error, ["could not compute balance"]}
     end

--- a/apps/app/test/app/balance_test.exs
+++ b/apps/app/test/app/balance_test.exs
@@ -135,8 +135,8 @@ defmodule App.BalanceTest do
         )
 
       assert Balance.fill_members_balance([member1, member2]) == [
-               %{member1 | balance: Money.new!(:EUR, "0.02")},
-               %{member2 | balance: Money.new!(:EUR, "-0.02")}
+               %{member1 | balance: Money.new!(:EUR, "0.01")},
+               %{member2 | balance: Money.new!(:EUR, "-0.01")}
              ]
     end
 
@@ -220,8 +220,8 @@ defmodule App.BalanceTest do
 
       [member1, member2, member3] = Balance.fill_members_balance([member1, member2, member3])
       assert Money.equal?(member1.balance, Money.new!(:EUR, "92.86"))
-      assert Money.equal?(member2.balance, Money.new!(:EUR, "-28.57"))
-      assert Money.equal?(member3.balance, Money.new!(:EUR, "-64.29"))
+      assert Money.equal?(member2.balance, Money.new!(:EUR, "-28.56"))
+      assert Money.equal?(member3.balance, Money.new!(:EUR, "-64.30"))
     end
 
     test "fails if a user config appropriate fields aren't set", %{book: book} do


### PR DESCRIPTION
- chore: remove useless `user_id: user_fixture().id` in book member fixtures
- fix: correctly divide amount between peers
