### PR TITLE
fix: make prod compilation work again

### DIFF
--- a/apps/app_web/lib/app_web/storybook.ex
+++ b/apps/app_web/lib/app_web/storybook.ex
@@ -10,5 +10,9 @@ defmodule AppWeb.Storybook do
     css_path: "/assets/app.css",
     js_path: "/assets/storybook.js",
     sandbox_class: "app-web",
-    title: "Anacounts Storybook"
+    title: "Anacounts Storybook",
+    # Set the compilation mode to `:lazy`. The storybook is only used in
+    # development, so we don't want to compile the files for nothing
+    # in test and production.
+    compilation_mode: :lazy
 end

--- a/apps/app_web/mix.exs
+++ b/apps/app_web/mix.exs
@@ -74,7 +74,7 @@ defmodule AppWeb.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
 
       # Dev tools
-      {:phoenix_storybook, "~> 0.6.3", only: [:dev, :test]},
+      {:phoenix_storybook, "~> 0.6.3", runtime: Mix.env() == :dev},
       {:heroicons, "~> 0.5.5", only: [:dev, :test]},
 
       # Umbrella


### PR DESCRIPTION
**The context**

The compilation of the project fails in prod environment since the introduction of Phoenix Storybook (see #220).

Indeed, I set the dependency as `:dev` and `:test` only, but the `PhoenixStorybook.*` modules need to be available at compilation for the compilation to work correctly.

**What does the PR do?**

Activate the dependency in all environments, but do start storybook only in `:dev` environment.
This way, the compilation works fine, but the storybook isn't started.
The routes were already hidden behind the `:dev_routes` config flag, so the router is not changing.

Also, to prevent it from compiling too many files for nothing, set the `:compilation_mode` to `:lazy` (see [Configuration](https://hexdocs.pm/phoenix_storybook/0.6.3/PhoenixStorybook.html#module-configuration)).
