### PR TITLE
chore(balance): rename `weight_by_income` to `weight_by_revenues`

### DIFF
--- a/apps/app/lib/app/balance.ex
+++ b/apps/app/lib/app/balance.ex
@@ -90,7 +90,7 @@ defmodule App.Balance do
   defp compute_peers_total_weight({:divide_equally, transfers}),
     do: compute_divide_equally_peers_total_weight(transfers)
 
-  defp compute_peers_total_weight({:weight_by_income, transfers}),
+  defp compute_peers_total_weight({:weight_by_revenues, transfers}),
     do: compute_weight_by_income_peers_total_weight(transfers)
 
   defp compute_divide_equally_peers_total_weight(transfers) do

--- a/apps/app/lib/app/transfers/money_transfer.ex
+++ b/apps/app/lib/app/transfers/money_transfer.ex
@@ -36,8 +36,8 @@ defmodule App.Transfers.MoneyTransfer do
   @type type :: :payment | :income | :reimbursement
   @transfer_types [:payment, :income, :reimbursement]
 
-  @type balance_means :: :divide_equally | :weight_by_income
-  @balance_means [:divide_equally, :weight_by_income]
+  @type balance_means :: :divide_equally | :weight_by_revenues
+  @balance_means [:divide_equally, :weight_by_revenues]
 
   schema "money_transfers" do
     field :label, :string

--- a/apps/app/priv/repo/migrations/20250112201549_rename_balance_means_weight_by_revenues.exs
+++ b/apps/app/priv/repo/migrations/20250112201549_rename_balance_means_weight_by_revenues.exs
@@ -1,0 +1,8 @@
+defmodule App.Repo.Migrations.RenameBalanceMeansWeightByRevenues do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TYPE balance_means RENAME VALUE 'weight_by_income' TO 'weight_by_revenues'",
+            "ALTER TYPE balance_means RENAME VALUE 'weight_by_revenues' TO 'weight_by_income'"
+  end
+end

--- a/apps/app/test/app/balance_test.exs
+++ b/apps/app/test/app/balance_test.exs
@@ -166,7 +166,7 @@ defmodule App.BalanceTest do
       transfer =
         money_transfer_fixture(book,
           tenant_id: member1.id,
-          balance_means: :weight_by_income,
+          balance_means: :weight_by_revenues,
           amount: Money.new!(:EUR, 30)
         )
 
@@ -195,7 +195,7 @@ defmodule App.BalanceTest do
       transfer =
         money_transfer_fixture(book,
           tenant_id: member1.id,
-          balance_means: :weight_by_income,
+          balance_means: :weight_by_revenues,
           amount: Money.new!(:EUR, 9)
         )
 
@@ -226,7 +226,7 @@ defmodule App.BalanceTest do
       transfer =
         money_transfer_fixture(book,
           tenant_id: member1.id,
-          balance_means: :weight_by_income,
+          balance_means: :weight_by_revenues,
           amount: Money.new!(:EUR, 100)
         )
 
@@ -270,7 +270,7 @@ defmodule App.BalanceTest do
       transfer1 =
         money_transfer_fixture(book,
           tenant_id: member1.id,
-          balance_means: :weight_by_income,
+          balance_means: :weight_by_revenues,
           amount: Money.new!(:EUR, 30)
         )
 
@@ -283,7 +283,7 @@ defmodule App.BalanceTest do
       transfer2 =
         money_transfer_fixture(book,
           tenant_id: member1.id,
-          balance_means: :weight_by_income,
+          balance_means: :weight_by_revenues,
           amount: Money.new!(:EUR, 40)
         )
 

--- a/apps/app/test/app/transfers_test.exs
+++ b/apps/app/test/app/transfers_test.exs
@@ -255,11 +255,11 @@ defmodule App.TransfersTest do
                  :payment,
                  money_transfer_attributes(
                    tenant_id: member.id,
-                   balance_means: :weight_by_income
+                   balance_means: :weight_by_revenues
                  )
                )
 
-      assert transfer.balance_means == :weight_by_income
+      assert transfer.balance_means == :weight_by_revenues
     end
 
     test "creates peers along the way", %{book: book, member: member} do
@@ -380,14 +380,14 @@ defmodule App.TransfersTest do
                  label: "my very own label !",
                  amount: Money.new!(:EUR, 299),
                  date: ~D[2020-06-29],
-                 balance_means: :weight_by_income,
+                 balance_means: :weight_by_revenues,
                  peers: [%{member_id: other_member.id}]
                })
 
       assert updated.label == "my very own label !"
       assert updated.amount == Money.new!(:EUR, 299)
       assert updated.date == ~D[2020-06-29]
-      assert updated.balance_means == :weight_by_income
+      assert updated.balance_means == :weight_by_revenues
 
       assert [peer] = updated.peers
       assert peer.member_id == other_member.id

--- a/apps/app_web/lib/app_web/components/transfers_components.ex
+++ b/apps/app_web/lib/app_web/components/transfers_components.ex
@@ -117,7 +117,7 @@ defmodule AppWeb.TransfersComponents do
   end
 
   defp format_balance_params_code(:divide_equally), do: gettext("Divided")
-  defp format_balance_params_code(:weight_by_income), do: gettext("Weighted")
+  defp format_balance_params_code(:weight_by_revenues), do: gettext("Weighted")
 
   @doc """
   Transfer icons are based on the transfer type.

--- a/apps/app_web/lib/app_web/live/books/book_transfer_form_live.ex
+++ b/apps/app_web/lib/app_web/live/books/book_transfer_form_live.ex
@@ -193,7 +193,7 @@ defmodule AppWeb.BookTransferFormLive do
   defp balance_params_options do
     [
       {gettext("Divide equally"), "divide_equally"},
-      {gettext("Weight by income"), "weight_by_revenues"}
+      {gettext("Weight by revenues"), "weight_by_revenues"}
     ]
   end
 

--- a/apps/app_web/lib/app_web/live/books/book_transfer_form_live.ex
+++ b/apps/app_web/lib/app_web/live/books/book_transfer_form_live.ex
@@ -193,7 +193,7 @@ defmodule AppWeb.BookTransferFormLive do
   defp balance_params_options do
     [
       {gettext("Divide equally"), "divide_equally"},
-      {gettext("Weight by income"), "weight_by_income"}
+      {gettext("Weight by income"), "weight_by_revenues"}
     ]
   end
 

--- a/apps/app_web/priv/gettext/default.pot
+++ b/apps/app_web/priv/gettext/default.pot
@@ -603,7 +603,7 @@ msgid "Weight"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Weight by income"
+msgid "Weight by revenues"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/app_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/app_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -604,8 +604,8 @@ msgid "Weight"
 msgstr "Weight"
 
 #, elixir-autogen, elixir-format
-msgid "Weight by income"
-msgstr "Weight by income"
+msgid "Weight by revenues"
+msgstr "Weight by revenues"
 
 #, elixir-autogen, elixir-format
 msgid "Weighted"

--- a/apps/app_web/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/app_web/priv/gettext/fr/LC_MESSAGES/default.po
@@ -604,7 +604,7 @@ msgid "Weight"
 msgstr "Poids"
 
 #, elixir-autogen, elixir-format
-msgid "Weight by income"
+msgid "Weight by revenues"
 msgstr "Pondérer par revenu"
 
 #, elixir-autogen, elixir-format

--- a/apps/app_web/storybook/transfers_components/transfer_details.story.exs
+++ b/apps/app_web/storybook/transfers_components/transfer_details.story.exs
@@ -25,7 +25,7 @@ defmodule Storybook.TransfersComponents.TransferDetails do
                   nickname: "Jane Doe"
                 },
                 peers: [%Peer{}, %Peer{}],
-                balance_means: :weight_by_income
+                balance_means: :weight_by_revenues
               },
               style: "width: 20rem"
             }

--- a/apps/app_web/test/app_web/live/books/book_balance_live_test.exs
+++ b/apps/app_web/test/app_web/live/books/book_balance_live_test.exs
@@ -91,7 +91,7 @@ defmodule AppWeb.BookBalanceLiveTest do
       money_transfer_fixture(book,
         tenant_id: member.id,
         amount: Money.new!(:EUR, "100.00"),
-        balance_means: :weight_by_income
+        balance_means: :weight_by_revenues
       )
 
     balance_config = member_balance_config_fixture(member)

--- a/apps/app_web/test/app_web/live/books/book_transfer_form_live_test.exs
+++ b/apps/app_web/test/app_web/live/books/book_transfer_form_live_test.exs
@@ -69,7 +69,7 @@ defmodule AppWeb.BookTransferFormLiveTest do
           label: "Updated transfer",
           amount: "6.70",
           date: "2022-04-10",
-          balance_means: "weight_by_income"
+          balance_means: "weight_by_revenues"
         }
       )
       |> render_submit()
@@ -99,7 +99,7 @@ defmodule AppWeb.BookTransferFormLiveTest do
           label: "Updated transfer",
           amount: "6.70",
           date: "2022-04-10",
-          balance_means: "weight_by_income"
+          balance_means: "weight_by_revenues"
         }
       )
       |> render_submit()


### PR DESCRIPTION
- **chore(balance): replace `weight_by_income` to `*_revenue`**
- **chore(balance): replace `Weight by income` in UI**
- **chore(balance): add migration to rename enum**
